### PR TITLE
Add new 'raw' option to the format parameter and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ __Available Parameters:__
 | -------------- | ----------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `trackid `       | None                                             | String           | The trackid from spotify.                                                                                            |
 | `url`       | None                                              | String           | The url of the track from spotify.                                                                                            |
-| `format`        | `"id3"`                                                  | String           | The format of lyrics required. It has 2 options either `id3` or `lrc`. |
+| `format`        | `"id3"`                                                  | String           | The format of lyrics required. Options: `id3`, `lrc`, `srt`, `raw`. |
 
-> You must specify either __trackid__ or __url__, otherwise it will retuen error.
+> You must specify either __trackid__ or __url__, otherwise it will return error.
 
 ### Examples
 
@@ -235,7 +235,7 @@ export SP_DC=[token here and remove the square brackets]
 
 __Start the server__
 ```
-php -S localhost:8000 api/index.php
+php -S localhost:8080 api/index.php
 ```
 now open your browser and type `localhost:8080` and you should see the program running.
 # Credits

--- a/api/index.php
+++ b/api/index.php
@@ -36,11 +36,12 @@ function make_response($spotify, $response, $format)
         http_response_code(404);
         return json_encode(['error' => true, 'message' => 'lyrics for this track is not available on spotify!']);
     }
-    $lines = $format == 'lrc' ? $spotify->getLrcLyrics($json_res['lyrics']['lines']) : $json_res['lyrics']['lines'];
     if ($format == 'lrc') {
         $lines = $spotify->getLrcLyrics($json_res['lyrics']['lines']);
     } elseif ($format == 'srt') {
         $lines = $spotify->getSrtLyrics($json_res['lyrics']['lines']);
+    } elseif ($format == 'raw') {
+        $lines = $spotify->getRawLyrics($json_res['lyrics']['lines']);
     } else {
         $lines =  $json_res['lyrics']['lines'];
     }

--- a/src/Spotify.php
+++ b/src/Spotify.php
@@ -241,6 +241,21 @@ class Spotify
     }
 
     /**
+     * Retrieves the lyrics in plain text format.
+     *
+     * @param array $lyrics The lyrics data.
+     * @return string The lyrics in plain text.
+     */
+    function getRawLyrics($lyrics): string
+    {
+        $raw = "";
+        foreach ($lyrics as $lines) {
+            $raw .= $lines['words'] . "\n";
+        }
+        return $raw;
+    }
+
+    /**
      * Helper fucntion for getLrcLyrics to change miliseconds to [ mm:ss.xx ]
      * @param int $milliseconds The time in miliseconds.
      * @return string The time in [ mm:ss.xx ] format.


### PR DESCRIPTION
## Summary
I added a new option called `raw` for the `format` parameter. This allows users to get the lyrics as one simple block of text instead of a list of timed lines.

## What's New
- **New Format**: You can now use `?format=raw` to get plain text lyrics.
- **Updated README.md**: I updated the README.md  for the new raw format and to include minor improvements.

## How it looks
If you request `?format=raw`, the response now looks like this:
{
    "error": false,
    "syncType": "LINE_SYNCED",
    "lines": "First line of the song\nSecond line of the song..."
}